### PR TITLE
Fix exclusion of environment compiler

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+????-??-?? David Allsopp <david.allsopp -at- metastack.com>
+  Next
+* Fix error excluding environment compiler when either LIB or INCLUDE is not
+  set (report from npmazzuca -at- gmail.com)
+
 2018-01-03 David Allsopp <david.allsopp -at- metastack.com>
   Version 0.3.2
 * Ensure commands run by msvs-promote-path don't write to stderr

--- a/msvs-detect
+++ b/msvs-detect
@@ -109,6 +109,7 @@ find_in ()
 # entire runtime if only some options (e.g. Dynamic Runtime and not Static) are selected.
 check_environment ()
 {
+  debug 4 "Checking $4 ($5)"
   for tool in cl rc link ; do
     find_in "$1" $tool.exe
   done
@@ -547,21 +548,26 @@ if [[ $SCAN_ENV -eq 1 ]] ; then
       RET=0
       ENV_INC=$(env | sed -ne 's/^\(INCLUDE\)=.*/\1/pi')
       ENV_LIB=$(env | sed -ne 's/^\(LIB\)=.*/\1/pi')
-      if check_environment "${PATH//:/*}" \
-                           "${!ENV_INC//;/*}" \
-                           "${!ENV_LIB//;/*}" \
-                           "Environment C compiler" \
-                           "$ENV_ARCH" ; then
-        ENV_CL=$(which cl)
-        ENV_cl=${ENV_CL,,}
-        ENV_cl=${ENV_cl/bin\/*_/bin\/}
-        debug "Environment appears to include a compiler at $ENV_CL"
-        if [[ -n $TARGET_ARCH && $TARGET_ARCH != $ENV_ARCH ]] ; then
-          debug "But architecture doesn't match required value"
+      if [[ -z $ENV_INC || -z $ENV_LIB ]] ; then
+        warning "Microsoft C Compiler Include and/or Lib not set - Environment C compiler ($ENV_ARCH) excluded"
+        unset ENV_ARCH
+      else
+        if check_environment "${PATH//:/*}" \
+                             "${!ENV_INC//;/*}" \
+                             "${!ENV_LIB//;/*}" \
+                             "Environment C compiler" \
+                             "$ENV_ARCH" ; then
+          ENV_CL=$(which cl)
+          ENV_cl=${ENV_CL,,}
+          ENV_cl=${ENV_cl/bin\/*_/bin\/}
+          debug "Environment appears to include a compiler at $ENV_CL"
+          if [[ -n $TARGET_ARCH && $TARGET_ARCH != $ENV_ARCH ]] ; then
+            debug "But architecture doesn't match required value"
+            unset ENV_ARCH
+          fi
+        else
           unset ENV_ARCH
         fi
-      else
-        unset ENV_ARCH
       fi
     fi
   fi


### PR DESCRIPTION
If `cl` is found in `PATH`, but `Include` or `Lib` are not set, then the environment compiler is clearly not valid, but the detection failed to exclude it.

Fixes (or at least ignores the invalid configuration) reported by @ubsan in https://github.com/ocaml/opam/issues/3257#issuecomment-373323232
