### PR TITLE
Fix path blow-up with environment compiler

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 msvs-detect text eol=lf
 msvs-promote-path text eol=lf
+appveyor.sh text eol=lf

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,8 @@
 ????-??-?? David Allsopp <david.allsopp -at- metastack.com>
   Next
+* Improve tail-stripping of MSVS_PATH to prevent path blow-out. More recent
+  Visual Studios add some elements for extensions to the end of PATH. This
+  should eliminate msvs-detect ever including the original PATH in MSVS_PATH
 * Erase %ORIGINALPATH% to deal with SetEnv scripts overridding PATH. Doesn't
   appear to be needed for the newer equivalent VSCMD variable
 * Ensure PATH-mangling never overrides Cygwin bin (in particular, ensure `which`

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 ????-??-?? David Allsopp <david.allsopp -at- metastack.com>
   Next
+* Erase %ORIGINALPATH% to deal with SetEnv scripts overridding PATH. Doesn't
+  appear to be needed for the newer equivalent VSCMD variable
 * Ensure PATH-mangling never overrides Cygwin bin (in particular, ensure `which`
   is always from the same Cygwin as the script)
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+????-??-?? David Allsopp <david.allsopp -at- metastack.com>
+  Next
+* Ensure PATH-mangling never overrides Cygwin bin (in particular, ensure `which`
+  is always from the same Cygwin as the script)
+
 2019-06-13 David Allsopp <david.allsopp -at- metastack.com>
   Version 0.4.0
 * Fix error excluding environment compiler when either LIB or INCLUDE is not

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -25,6 +25,9 @@ if "$WHICH" cl &> /dev/null ; then
   cl &> env-cl || true
 fi
 eval $(./msvs-detect)
+echo -e "MSVS_PATH = \033[30m$MSVS_PATH\033[0m"
+echo -e "MSVS_INC = \033[30m$MSVS_INC\033[0m"
+echo -e "MSVS_LIB = \033[30m$MSVS_LIB\033[0m"
 if ! PATH="$MSVS_PATH:$PATH" "$WHICH" cl ; then
   exit 1
 else

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -e
+
+test ()
+{
+  echo
+  echo -e "\033[33m** \033[32m$1\033[0m"
+}
+
+if [[ $1 = 'env' ]] ; then
+  echo -e '\033[33mRe-running tests with an environment compiler already set\033[0m'
+  TEST_MSVS_PROMOTE_PATH=1
+else
+  TEST_MSVS_PROMOTE_PATH=0
+fi
+
+WHICH=$(which which)
+
+test 'Test msvs-detect --all'
+./msvs-detect --all
+
+test 'Ensure msvs-detect locates a compiler'
+if "$WHICH" cl &> /dev/null ; then
+  cl &> env-cl || true
+fi
+eval $(./msvs-detect)
+if ! PATH="$MSVS_PATH:$PATH" "$WHICH" cl ; then
+  exit 1
+else
+  if [[ -e detected-cl ]] ; then
+    mv detected-cl first-cl
+  fi
+  PATH="$MSVS_PATH:$PATH" cl &> detected-cl || true
+fi
+cat detected-cl
+if [[ -e env-cl ]] ; then
+  test 'Ensure msvs-detect prefers the environment compiler'
+  diff env-cl detected-cl
+  diff -q first-cl detected-cl &> /dev/null && exit 1
+fi
+
+if [[ $TEST_MSVS_PROMOTE_PATH -eq 1 ]] ; then
+  test 'Test msvs-promote-path'
+  echo "link is currently: $("$WHICH" link)"
+  eval $(./msvs-promote-path)
+  echo "link is now: $("$WHICH" link)"
+  if link --version &> /dev/null ; then
+    exit 1
+  fi
+fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,12 +35,9 @@ environment:
   CYG_ROOT: C:\cygwin64
 
 build_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
   - |
-    %CYG_ROOT%\bin\bash.exe -lc "$APPVEYOR_BUILD_FOLDER/msvs-detect --all"
+    %CYG_ROOT%\bin\bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER ; ./appveyor.sh"
+  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
   - |
-    %CYG_ROOT%\bin\bash.exe -lc "eval $($APPVEYOR_BUILD_FOLDER/msvs-detect); PATH=$MSVS_PATH:$PATH cl"
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
-  - |
-    %CYG_ROOT%\bin\bash.exe -lc "which link"
-  - |
-    %CYG_ROOT%\bin\bash.exe -lc "which link; eval $($APPVEYOR_BUILD_FOLDER/msvs-promote-path); which link; if link --version &>/dev/null ; then exit 1 ; fi"
+    %CYG_ROOT%\bin\bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER ; ./appveyor.sh env"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,3 +41,8 @@ build_script:
   - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
   - |
     %CYG_ROOT%\bin\bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER ; ./appveyor.sh env"
+
+# Uncomment this to enable Remote Desktop on the build worker at the end of the
+# build. The worker is available for the remainder of the allocated hour.
+#on_finish:
+#    - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/msvs-detect
+++ b/msvs-detect
@@ -201,6 +201,9 @@ ML_REQUIRED=0
 TARGET_ARCH=
 SCAN_ENV=0
 
+# Various PATH messing around means it's sensible to know where tools are now
+WHICH=$(which which)
+
 if [[ $(uname --operating-system 2>/dev/null) = "Msys" ]] ; then
   # Prevent MSYS from translating command line switches to paths
   SWITCH_PREFIX='//'
@@ -535,7 +538,7 @@ FOUND=()
 # Scan the environment for a C compiler, and check that it's valid. Throughout the rest of the
 # script, it is assumed that if ENV_ARCH is set then there is a valid environment compiler.
 if [[ $SCAN_ENV -eq 1 ]] ; then
-  if which cl >/dev/null 2>&1 ; then
+  if "$WHICH" cl >/dev/null 2>&1 ; then
     # Determine its architecture from the Microsoft Logo line.
     ENV_ARCH=$(cl 2>&1 | head -1 | tr -d '\r')
     case "${ENV_ARCH#* for }" in
@@ -567,7 +570,7 @@ if [[ $SCAN_ENV -eq 1 ]] ; then
                              "${!ENV_LIB//;/*}" \
                              "Environment C compiler" \
                              "$ENV_ARCH" ; then
-          ENV_CL=$(which cl)
+          ENV_CL=$("$WHICH" cl)
           ENV_cl=${ENV_CL,,}
           ENV_cl=${ENV_cl/bin\/*_/bin\/}
           debug "Environment appears to include a compiler at $ENV_CL"
@@ -970,7 +973,7 @@ for i in "${TEST[@]}" ; do
 
       # Check to see if this is a match for the environment C compiler.
       if [[ -n ${ENV_ARCH+x} ]] ; then
-        TEST_cl=$(PATH="$MSVS_PATH:$PATH" which cl)
+        TEST_cl=$(PATH="$MSVS_PATH:$PATH" "$WHICH" cl)
         TEST_cl=${TEST_cl,,}
         TEST_cl=${TEST_cl/bin\/*_/bin\/}
         if [[ $TEST_cl = $ENV_cl ]] ; then

--- a/msvs-detect
+++ b/msvs-detect
@@ -899,6 +899,8 @@ for i in "${TEST[@]}" ; do
     ARCHS=${COMPILER["ARCH"]}
   fi
 
+  # Remove any trailing / from elements of $PATH
+  TRIM_PATH=$(echo "$PATH" | sed -e 's|\([^:]\)/\+\(:\|$\)|\1\2|g')
   for arch in $ARCHS ; do
     # Determine the command line switch for this architecture
     if [[ -n ${ARCHINFO[$arch]+x} ]] ; then
@@ -941,8 +943,10 @@ for i in "${TEST[@]}" ; do
     if [[ -n $MSVS_PATH ]] ; then
       # Translate MSVS_PATH back to Cygwin notation (/cygdrive, etc. and colon-separated)
       MSVS_PATH=$(cygpath "$MSVS_PATH" -p)
+      # Remove any trailing / from elements of MSVS_PATH
+      MSVS_PATH=$(echo "$MSVS_PATH" | sed -e 's|\([^:]\)/\+\(:\|$\)|\1\2|g')
       # Remove the actual PATH (and the extra $DIR added to run the script)
-      MSVS_PATH=${MSVS_PATH%:$DIR:$PATH}
+      MSVS_PATH=${MSVS_PATH%:$DIR:$TRIM_PATH}
       # Guarantee that MSVS_PATH ends with a single :
       MSVS_PATH="${MSVS_PATH%%:}:"
     fi

--- a/msvs-detect
+++ b/msvs-detect
@@ -933,7 +933,7 @@ for i in "${TEST[@]}" ; do
           MSVS_INC=${line%% };;
       esac
       ((num++))
-    done < <(INCLUDE= LIB= PATH="$DIR:$PATH" \
+    done < <(INCLUDE= LIB= PATH="$DIR:$PATH" ORIGINALPATH= \
              EXEC_SCRIPT="$(basename "$SCRIPT") $ARCH_SWITCHES $SCRIPT_SWITCHES" \
              $(cygpath "$COMSPEC") ${SWITCH_PREFIX}v:on ${SWITCH_PREFIX}c $COMMAND 2>/dev/null | fgrep XMARKER -A 3 | tr -d '\015' | tail -3)
     if [[ $DEBUG -gt 3 ]] ; then

--- a/msvs-detect
+++ b/msvs-detect
@@ -933,7 +933,7 @@ for i in "${TEST[@]}" ; do
           MSVS_INC=${line%% };;
       esac
       ((num++))
-    done < <(INCLUDE= LIB= PATH="$DIR:$PATH" ORIGINALPATH= \
+    done < <(INCLUDE= LIB= PATH="?msvs-detect?:$DIR:$PATH" ORIGINALPATH= \
              EXEC_SCRIPT="$(basename "$SCRIPT") $ARCH_SWITCHES $SCRIPT_SWITCHES" \
              $(cygpath "$COMSPEC") ${SWITCH_PREFIX}v:on ${SWITCH_PREFIX}c $COMMAND 2>/dev/null | fgrep XMARKER -A 3 | tr -d '\015' | tail -3)
     if [[ $DEBUG -gt 3 ]] ; then
@@ -944,9 +944,7 @@ for i in "${TEST[@]}" ; do
       # Translate MSVS_PATH back to Cygwin notation (/cygdrive, etc. and colon-separated)
       MSVS_PATH=$(cygpath "$MSVS_PATH" -p)
       # Remove any trailing / from elements of MSVS_PATH
-      MSVS_PATH=$(echo "$MSVS_PATH" | sed -e 's|\([^:]\)/\+\(:\|$\)|\1\2|g')
-      # Remove the actual PATH (and the extra $DIR added to run the script)
-      MSVS_PATH=${MSVS_PATH%:$DIR:$TRIM_PATH}
+      MSVS_PATH=$(echo "$MSVS_PATH" | sed -e 's|\([^:]\)/\+\(:\|$\)|\1\2|g;s/?msvs-detect?.*//')
       # Guarantee that MSVS_PATH ends with a single :
       MSVS_PATH="${MSVS_PATH%%:}:"
     fi


### PR DESCRIPTION
Testsuite slightly improved.

Deals with the path blow-up in https://github.com/ocaml/opam/pull/4242 (opam's script invokes msvs-detect and then so does flexdll)