### PR TITLE
Shellcheck

### DIFF
--- a/msvs-detect
+++ b/msvs-detect
@@ -87,7 +87,7 @@ find_in ()
   if [[ $STATUS -eq 1 ]] ; then
     debug 4 "$2 not found"
   fi
-  ((RET+=$STATUS))
+  ((RET+=STATUS))
 }
 
 # check_environment PATH INC LIB name arch

--- a/msvs-detect
+++ b/msvs-detect
@@ -931,7 +931,7 @@ for i in "${TEST[@]}" ; do
           MSVS_INC=${line%% };;
       esac
       ((num++))
-    done < <(INCLUDE= LIB= PATH="?msvs-detect?:$DIR:$PATH" ORIGINALPATH= \
+    done < <(INCLUDE='' LIB='' PATH="?msvs-detect?:$DIR:$PATH" ORIGINALPATH='' \
              EXEC_SCRIPT="$(basename "$SCRIPT") $ARCH_SWITCHES $SCRIPT_SWITCHES" \
              $(cygpath "$COMSPEC") ${SWITCH_PREFIX}v:on ${SWITCH_PREFIX}c $COMMAND 2>/dev/null | grep -F XMARKER -A 3 | tr -d '\015' | tail -3)
     if [[ $DEBUG -gt 3 ]] ; then

--- a/msvs-detect
+++ b/msvs-detect
@@ -803,7 +803,7 @@ for i in $MSVS_PREFERENCE ; do
       SDKS=
       for j in "${!COMPILERS[@]}" ; do
         eval COMPILER=${COMPILERS[$j]}
-        if [[ -n ${COMPILER["VC_VER"]}+x ]] ; then
+        if [[ -n ${COMPILER["VC_VER"]+x} ]] ; then
           if [[ $i = ${COMPILER["VC_VER"]} && -n ${CANDIDATES[$j]+x} ]] ; then
             unset CANDIDATES[$j]
             SDKS="$j $SDKS"
@@ -1101,4 +1101,3 @@ if [[ -n $SOLUTION ]] ; then
 else
   exit 1
 fi
-

--- a/msvs-detect
+++ b/msvs-detect
@@ -76,7 +76,7 @@ find_in ()
   else
     IFS=*
     STATUS=1
-    for f in $1; do 
+    for f in $1; do
       if [[ -e "$f/$2" ]] ; then
         STATUS=0
         break

--- a/msvs-detect
+++ b/msvs-detect
@@ -933,7 +933,7 @@ for i in "${TEST[@]}" ; do
       ((num++))
     done < <(INCLUDE= LIB= PATH="?msvs-detect?:$DIR:$PATH" ORIGINALPATH= \
              EXEC_SCRIPT="$(basename "$SCRIPT") $ARCH_SWITCHES $SCRIPT_SWITCHES" \
-             $(cygpath "$COMSPEC") ${SWITCH_PREFIX}v:on ${SWITCH_PREFIX}c $COMMAND 2>/dev/null | fgrep XMARKER -A 3 | tr -d '\015' | tail -3)
+             $(cygpath "$COMSPEC") ${SWITCH_PREFIX}v:on ${SWITCH_PREFIX}c $COMMAND 2>/dev/null | grep -F XMARKER -A 3 | tr -d '\015' | tail -3)
     if [[ $DEBUG -gt 3 ]] ; then
       echo done>&2
     fi

--- a/msvs-promote-path
+++ b/msvs-promote-path
@@ -43,7 +43,7 @@ do
     T="$i"
     FIRST=0
   else
-    if [ $FOUND -eq 0 -a -x $i/link ] && [ "$($i/link --version 2>/dev/null | sed -ne "1s/Microsoft (R) Incremental Linker//p")" != "" ] ; then
+    if [ $FOUND -eq 0 ] && [ -x $i/link ] && [ "$($i/link --version 2>/dev/null | sed -ne "1s/Microsoft (R) Incremental Linker//p")" != "" ] ; then
       FOUND=1
       T="$i:$T"
       PROM=$i

--- a/msvs-promote-path
+++ b/msvs-promote-path
@@ -43,7 +43,7 @@ do
     T="$i"
     FIRST=0
   else
-    if [ $FOUND -eq 0 ] && [ -x $i/link ] && [ "$($i/link --version 2>/dev/null | sed -ne "1s/Microsoft (R) Incremental Linker//p")" != "" ] ; then
+    if [ $FOUND -eq 0 ] && [ -x "$i/link" ] && [ "$("$i/link" --version 2>/dev/null | sed -ne "1s/Microsoft (R) Incremental Linker//p")" != "" ] ; then
       FOUND=1
       T="$i:$T"
       PROM=$i
@@ -55,9 +55,9 @@ done
 unset IFS
 
 if [ $FOUND -eq 0 ] ; then
-  echo The Microsoft Linker was not found in any of the PATH entries!>&2
+  echo "The Microsoft Linker was not found in any of the PATH entries!">&2
   exit 1
 else
   echo "$PROM moved to the front of \$PATH">&2
-  echo export PATH=\"$T\"
+  echo "export PATH=\"$T\""
 fi


### PR DESCRIPTION
I ran [Shellcheck](https://www.shellcheck.net/) on the scripts and fixed warnings on top of https://github.com/metastack/msvs-tools/pull/6 (I’ll rebase if you push more commits).
There are some warnings remaining. Those about quoting seem false-positives, you may want to look at the others.

```
In msvs-detect line 217:
if [[ $@ != "" ]] ; then
      ^-- SC2199: Arrays implicitly concatenate in [[ ]]. Use a loop (or explicit * instead of @).


In msvs-detect line 425:
SDK52_KEY='HKLM\SOFTWARE\Microsoft\MicrosoftSDK\InstalledSDKs\8F9E5EF3-A9A5-491B-A889-C58EFFECE8B3'
^-------^ SC2034: SDK52_KEY appears unused. Verify use (or export if used externally).


In msvs-detect line 483:
  ["SDK5.2"]='(
             ^-- SC2016: Expressions don't expand in single quotes, use double quotes for that.


In msvs-detect line 903:
  TRIM_PATH=$(echo "$PATH" | sed -e 's|\([^:]\)/\+\(:\|$\)|\1\2|g')
  ^-------^ SC2034: TRIM_PATH appears unused. Verify use (or export if used externally).


In msvs-detect line 938:
             $(cygpath "$COMSPEC") ${SWITCH_PREFIX}v:on ${SWITCH_PREFIX}c $COMMAND 2>/dev/null | grep -F XMARKER -A 3 | tr -d '\015' | tail -3)
                                                                          ^------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
             $(cygpath "$COMSPEC") ${SWITCH_PREFIX}v:on ${SWITCH_PREFIX}c "$COMMAND" 2>/dev/null | grep -F XMARKER -A 3 | tr -d '\015' | tail -3)


In msvs-detect line 1059:
    TEST_ARCH=$TARGET_ARCH
    ^-------^ SC2034: TEST_ARCH appears unused. Verify use (or export if used externally).

For more information:
  https://www.shellcheck.net/wiki/SC2199 -- Arrays implicitly concatenate in ...
  https://www.shellcheck.net/wiki/SC2034 -- SDK52_KEY appears unused. Verify ...
  https://www.shellcheck.net/wiki/SC2016 -- Expressions don't expand in singl...
```

Shellcheck doesn’t parse the construct `eval array+=(element)`. Temporary applying this patch is needed to make it parse the file:
```diff
diff --git a/msvs-detect b/msvs-detect
index e920ea9..eca6b53 100755
--- a/msvs-detect
+++ b/msvs-detect
@@ -791,8 +791,8 @@ for i in $MSVS_PREFERENCE ; do
           fi
         done
         INSTANCES="$(sort -r <<< "${INSTANCES// /$'\n'}")"
-        eval TEST+=($INSTANCES)
-        eval PREFERENCE+=($INSTANCES)
+        # eval TEST+=($INSTANCES)
+        # eval PREFERENCE+=($INSTANCES)
       fi
     else
       if [[ -n ${CANDIDATES["VS$i"]+x} ]] ; then
@@ -813,8 +813,8 @@ for i in $MSVS_PREFERENCE ; do
       SDKS=${SDKS% }
       SDKS="$(sort -r <<< "${SDKS// /$'\n'}")"
       SDKS=${SDKS//$'\n'/ }
-      eval TEST+=($SDKS)
-      eval PREFERENCE+=($SDKS)
+      # eval TEST+=($SDKS)
+      # eval PREFERENCE+=($SDKS)
     fi
   fi
 done
```