### PR TITLE
Support Build Tools

### DIFF
--- a/msvs-detect
+++ b/msvs-detect
@@ -977,8 +977,12 @@ for i in "${TEST[@]}" ; do
         TEST_cl=${TEST_cl,,}
         TEST_cl=${TEST_cl/bin\/*_/bin\/}
         if [[ $TEST_cl = $ENV_cl ]] ; then
-          if [[ ${!ENV_INC/"$MSVS_INC"/} != "${!ENV_INC}" && \
-                ${!ENV_LIB/"$MSVS_LIB"/} != "${!ENV_LIB}" ]] ; then
+          # Create trailing semi-colon versions of the expansions of ENV_ for comparison with MSVS_
+          ENV_EXPAND_INC="${!ENV_INC%%;};"
+          ENV_EXPAND_LIB="${!ENV_LIB%%;};"
+
+          if [[ ${ENV_EXPAND_INC/"$MSVS_INC"/} != "${ENV_EXPAND_INC}" && \
+                ${ENV_EXPAND_LIB/"$MSVS_LIB"/} != "${ENV_EXPAND_LIB}" ]] ; then
             debug "$i-$arch is a strong candidate for the Environment C compiler"
             if [[ -n ${ENV_COMPILER+x} ]] ; then
               if [[ -z ${ENV_COMPILER} ]] ; then

--- a/msvs-detect
+++ b/msvs-detect
@@ -733,7 +733,7 @@ if [[ -x $VSWHERE ]] ; then
           warning "vcvarsall.bat not found for $INSTANCE"
         fi;;
     esac
-  done < <("$VSWHERE" -all -nologo | tr -d '\r')
+  done < <("$VSWHERE" -all -products '*' -nologo | tr -d '\r')
 fi
 
 if [[ $DEBUG -gt 1 ]] ; then


### PR DESCRIPTION
Changes:

1. Visual Studio can install Build Tools which is not detected by default by `vswhere.exe`. This PR adds `-products *` to the vswhere command line options.
    So `& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -all` which is the existing code does not detect Build Tools installations.
    While `& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -all -products *` does detect Build Tools installations.
2. There is a small bug with the strong/weak detection logic. Before it compared a guaranteed semicolon terminated path with a possibly semicolon terminated path; this PR makes sure both side of the comparison are done with semicolon termination.

(Can split PR if needed)