### PR TITLE
Fix `msvs-promote-path` when `PATH` contains characters needing escaping

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 ????-??-?? David Allsopp <david.allsopp -at- metastack.com>
   Next
+* Handle special characters in PATH in msvs-promote-path (in particular, stray
+  double-quote characters don't corrupt the command line)
 * Fix strong/weak detection of the environment compiler (Jonah Beckford)
 * Fix the vswhere invocation to detect Build Tools (Jonah Beckford)
 

--- a/msvs-promote-path
+++ b/msvs-promote-path
@@ -4,7 +4,7 @@
 # ################################################################################################ #
 # Microsoft Linker Cygwin PATH Munging Script                                                      #
 # ################################################################################################ #
-# Copyright (c) 2015, 2016, 2018, 2019, 2020 MetaStack Solutions Ltd.                              #
+# Copyright (c) 2015, 2016, 2018, 2019, 2020, 2021 MetaStack Solutions Ltd.                        #
 # ################################################################################################ #
 # Author: David Allsopp                                                                            #
 # 23-Dec-2015                                                                                      #
@@ -59,5 +59,5 @@ if [ $FOUND -eq 0 ] ; then
   exit 1
 else
   echo "$PROM moved to the front of \$PATH">&2
-  echo "export PATH=\"$T\""
+  echo "export PATH='$(echo "$T" | sed -e "s/'/'\"'\"'/g")'"
 fi


### PR DESCRIPTION
Double-quotes in `PATH` were not correctly escaped (neither would backslashes, but they're less likely to have appeared). This hardens it completely by using a single-quoted string and translating any nefarious single quotes to `'"'"'`.