### PR TITLE
Some modernisations, some corrections/hardening, some pedantry

### DIFF
--- a/msvs-detect
+++ b/msvs-detect
@@ -1057,7 +1057,6 @@ if [[ $MODE -eq 0 ]] ; then
   if [[ -z ${SOLUTION+x} ]] ; then
     ((pref++))
     debug "Search remaining: ${PREFERENCE[*]}"
-    TEST_ARCH=$TARGET_ARCH
     for i in "${PREFERENCE[@]:$pref}" ; do
       if [[ -n ${FOUND["$i-$LEFT_ARCH"]+x} && -n ${FOUND["$i-$RIGHT_ARCH"]+x} ]] ; then
         debug "Solved TARGET_ARCH='$TARGET_ARCH' with $i"

--- a/msvs-detect
+++ b/msvs-detect
@@ -932,7 +932,7 @@ for i in "${TEST[@]}" ; do
     done < <(INCLUDE='' LIB='' PATH="?msvs-detect?:$DIR:$PATH" ORIGINALPATH='' \
              EXEC_SCRIPT="$(basename "$SCRIPT") $ARCH_SWITCHES $SCRIPT_SWITCHES" \
              MSYS2_ARG_CONV_EXCL='*' \
-             $(cygpath "$COMSPEC") /v:on /c $COMMAND 2>/dev/null | grep -F XMARKER -A 3 | tr -d '\015' | tail -3)
+             $(cygpath "$COMSPEC") /v:on /c "$COMMAND" 2>/dev/null | grep -F XMARKER -A 3 | tr -d '\015' | tail -3)
     if [[ $DEBUG -gt 3 ]] ; then
       echo 'done'>&2
     fi

--- a/msvs-detect
+++ b/msvs-detect
@@ -415,7 +415,9 @@ esac
 # copied to the appropriate version. SDKs after 7.1 do not include compilers, and so are not
 # captured (as of Visual Studio 2015, the Windows SDK is official part of Visual Studio).
 declare -A COMPILERS
+# shellcheck disable=SC2034 # SDK52_KEY is used in COMPILERS which is eval'd...
 SDK52_KEY='HKLM\SOFTWARE\Microsoft\MicrosoftSDK\InstalledSDKs\8F9E5EF3-A9A5-491B-A889-C58EFFECE8B3'
+# shellcheck disable=SC2016 # ... and is therefore intentionally in a quoted string
 COMPILERS=(
   ["VS7.0"]='(
     ["NAME"]="Visual Studio .NET 2002"

--- a/msvs-detect
+++ b/msvs-detect
@@ -164,7 +164,7 @@ check_environment ()
 # value (i.e. no change) is output.
 output ()
 {
-  if [[ $3 = $ENV_ARCH ]] ; then
+  if [[ $3 = "$ENV_ARCH" ]] ; then
     VALUE=
   else
     VALUE=$2
@@ -570,7 +570,7 @@ if [[ $SCAN_ENV -eq 1 ]] ; then
           ENV_cl=${ENV_CL,,}
           ENV_cl=${ENV_cl/bin\/*_/bin\/}
           debug "Environment appears to include a compiler at $ENV_CL"
-          if [[ -n $TARGET_ARCH && $TARGET_ARCH != $ENV_ARCH ]] ; then
+          if [[ -n $TARGET_ARCH && $TARGET_ARCH != "$ENV_ARCH" ]] ; then
             debug "But architecture doesn't match required value"
             unset ENV_ARCH
           fi
@@ -781,7 +781,7 @@ for i in $MSVS_PREFERENCE ; do
       elif [[ ${i#*.} = "*" ]] ; then
         INSTANCES=
         for j in "${!CANDIDATES[@]}" ; do
-          if [[ "${j%.*}.*" = $i ]] ; then
+          if [[ "${j%.*}.*" = "$i" ]] ; then
             unset CANDIDATES[$j]
             INSTANCES="$INSTANCES $j"
           fi
@@ -800,7 +800,7 @@ for i in $MSVS_PREFERENCE ; do
       for j in "${!COMPILERS[@]}" ; do
         eval "COMPILER=${COMPILERS["$j"]}"
         if [[ -n ${COMPILER["VC_VER"]+x} ]] ; then
-          if [[ $i = ${COMPILER["VC_VER"]} && -n ${CANDIDATES[$j]+x} ]] ; then
+          if [[ $i = "${COMPILER["VC_VER"]}" && -n ${CANDIDATES[$j]+x} ]] ; then
             unset CANDIDATES[$j]
             SDKS="$j $SDKS"
           fi
@@ -975,7 +975,7 @@ for i in "${TEST[@]}" ; do
         TEST_cl=$(PATH="$MSVS_PATH:$PATH" "$WHICH" cl)
         TEST_cl=${TEST_cl,,}
         TEST_cl=${TEST_cl/bin\/*_/bin\/}
-        if [[ $TEST_cl = $ENV_cl ]] ; then
+        if [[ $TEST_cl = "$ENV_cl" ]] ; then
           # Create trailing semi-colon versions of the expansions of ENV_ for comparison with MSVS_
           ENV_EXPAND_INC="${!ENV_INC%%;};"
           ENV_EXPAND_LIB="${!ENV_LIB%%;};"
@@ -1012,7 +1012,7 @@ for i in "${TEST[@]}" ; do
   # Does this package match the current preference? Note that PREFERENCE and TEST are constructed in
   # a cunning (and hopefully not too "You are not expected to understand this" way) such that $PREF
   # will always equal $i, unless $PREF = "@".
-  if [[ $PREF = $i ]] ; then
+  if [[ $PREF = "$i" ]] ; then
     # In which case, check that the architecture(s)s were found
     if [[ -n ${FOUND["$i-$LEFT_ARCH"]+x} && -n ${FOUND["$i-$RIGHT_ARCH"]+x} ]] ; then
       debug "Solved TARGET_ARCH=$TARGET_ARCH with $i"

--- a/msvs-detect
+++ b/msvs-detect
@@ -775,14 +775,14 @@ for i in $MSVS_PREFERENCE ; do
   else
     if [[ -n ${COMPILERS[$i]+x} || -n ${COMPILERS[${i%.*}.*]+x} ]] ; then
       if [[ -n ${CANDIDATES[$i]+x} ]] ; then
-        unset CANDIDATES[$i]
-        TEST+=($i)
-        PREFERENCE+=($i)
+        unset "CANDIDATES[$i]"
+        TEST+=("$i")
+        PREFERENCE+=("$i")
       elif [[ ${i#*.} = "*" ]] ; then
         INSTANCES=
         for j in "${!CANDIDATES[@]}" ; do
           if [[ "${j%.*}.*" = "$i" ]] ; then
-            unset CANDIDATES[$j]
+            unset "CANDIDATES[$j]"
             INSTANCES="$INSTANCES $j"
           fi
         done
@@ -792,7 +792,7 @@ for i in $MSVS_PREFERENCE ; do
       fi
     else
       if [[ -n ${CANDIDATES["VS$i"]+x} ]] ; then
-        unset CANDIDATES["VS$i"]
+        unset "CANDIDATES[VS$i]"
         TEST+=("VS$i")
         PREFERENCE+=("VS$i")
       fi
@@ -801,7 +801,7 @@ for i in $MSVS_PREFERENCE ; do
         eval "COMPILER=${COMPILERS["$j"]}"
         if [[ -n ${COMPILER["VC_VER"]+x} ]] ; then
           if [[ $i = "${COMPILER["VC_VER"]}" && -n ${CANDIDATES[$j]+x} ]] ; then
-            unset CANDIDATES[$j]
+            unset "CANDIDATES[$j]"
             SDKS="$j $SDKS"
           fi
         fi
@@ -819,9 +819,9 @@ done
 # them from FOUND so that they don't accidentally get reported on later.
 for i in "${!CANDIDATES[@]}" ; do
   if [[ $PREFER_ENV -eq 1 ]] ; then
-    TEST+=($i)
+    TEST+=("$i")
   else
-    unset FOUND[$i]
+    unset "FOUND[$i]"
   fi
 done
 
@@ -856,7 +856,7 @@ for i in "${TEST[@]}" ; do
   # At the end of this process, the keys of FOUND will be augmented with the architecture found in
   # each case (so if "VS14.0" was in FOUND from the scan and both the x86 and x64 compilers are
   # valid, then at the end of this loop FOUND will contain "VS14.0-x86" and "VS14.0-x64").
-  unset FOUND[$i]
+  unset "FOUND[$i]"
 
   if [[ ${COMPILER["IS_EXPRESS"]}0 -gt 0 && -n ${COMPILER["EXPRESS_ARCH_SWITCHES"]+x} ]] ; then
     eval "ARCHINFO=${COMPILER['EXPRESS_ARCH_SWITCHES']}"

--- a/msvs-detect
+++ b/msvs-detect
@@ -702,7 +702,7 @@ for i in $(reg query "$SDK_ROOT" 2>/dev/null | tr -d '\r' | sed -ne '/Windows\\v
 done
 
 # Now enumerate Visual Studio 2017+ instances
-VSWHERE=$(dirname $(realpath $0))/vswhere.exe
+VSWHERE="$(dirname "$(realpath "$0")")/vswhere.exe"
 if [[ ! -x $VSWHERE ]] ; then
   VSWHERE="$(printenv 'ProgramFiles(x86)')\\Microsoft Visual Studio\\Installer\\vswhere.exe"
   VSWHERE=$(cygpath "$VSWHERE")

--- a/msvs-detect
+++ b/msvs-detect
@@ -74,7 +74,7 @@ find_in ()
   if [[ -z $1 ]] ; then
     STATUS=1
   else
-    IFS=*
+    IFS='*'
     STATUS=1
     for f in $1; do
       if [[ -e "$f/$2" ]] ; then
@@ -140,7 +140,7 @@ check_environment ()
   ASSEMBLER=${ASSEMBLER%86}.exe
   if [[ $ML_REQUIRED -eq 1 ]] ; then
     RET=0
-    find_in "$1" $ASSEMBLER
+    find_in "$1" "$ASSEMBLER"
     if [[ $RET -gt 0 ]] ; then
       warning "Microsoft Assembler ($ASSEMBLER) not found - $4 ($5)"
       return 1
@@ -934,7 +934,7 @@ for i in "${TEST[@]}" ; do
              MSYS2_ARG_CONV_EXCL='*' \
              $(cygpath "$COMSPEC") /v:on /c $COMMAND 2>/dev/null | grep -F XMARKER -A 3 | tr -d '\015' | tail -3)
     if [[ $DEBUG -gt 3 ]] ; then
-      echo done>&2
+      echo 'done'>&2
     fi
 
     if [[ -n $MSVS_PATH ]] ; then
@@ -962,7 +962,7 @@ for i in "${TEST[@]}" ; do
     fi
 
     # Ensure that these derived values give a valid compiler.
-    if check_environment "${MSVS_PATH//:/*}" "${MSVS_INC//;/*}" "${MSVS_LIB//;/*}" "$i" $arch ; then
+    if check_environment "${MSVS_PATH//:/*}" "${MSVS_INC//;/*}" "${MSVS_LIB//;/*}" "$i" "$arch" ; then
       # Put the package back into FOUND, but augmented with the architecture name and with the
       # derived values.
       FOUND["$i-$arch"]="${CURRENT%)} [\"MSVS_PATH\"]=\"$MSVS_PATH\" \
@@ -1041,7 +1041,7 @@ FLIP=(["x86"]="x64" ["x64"]="x86")
 
 if [[ $MODE -eq 0 ]] ; then
   if [[ $PREF = "@" && -n ${ENV_COMPILER} ]] ; then
-    SOLUTION=${ENV_COMPILER%-$ENV_ARCH}
+    SOLUTION=${ENV_COMPILER%-"$ENV_ARCH"}
     # If --arch wasn't specified, then ensure that the other architecture was also found. If --arch
     # was specified, then validate that the compiler was valid. This should always happen, unless
     # something went wrong running the script to get MSVS_PATH, MSVS_LIB and MSVS_INC.

--- a/msvs-detect
+++ b/msvs-detect
@@ -207,7 +207,7 @@ WHICH=$(which which)
 # Parse command-line. At the moment, the short option which usefully combines with anything is -d,
 # so for the time being, combining short options is not permitted, as the loop becomes even less
 # clear with getopts. GNU getopt isn't installed by default on Cygwin...
-if [[ $@ != "" ]] ; then
+if [[ $# -gt 0 ]] ; then
   while true ; do
     case "$1" in
       # Mode settings ($MODE)
@@ -316,7 +316,7 @@ if [[ $@ != "" ]] ; then
       echo "$0: cannot specify MSVS_PREFERENCE and --all">&2
       exit 2
     else
-      MSVS_PREFERENCE="$@"
+      MSVS_PREFERENCE="$*"
     fi
   fi
 fi

--- a/msvs-detect
+++ b/msvs-detect
@@ -604,7 +604,7 @@ declare -A COMPILER
 
 # Scan the registry for compiler package (vswhere is later)
 for i in "${!COMPILERS[@]}" ; do
-  eval COMPILER=${COMPILERS[$i]}
+  eval "COMPILER=${COMPILERS["$i"]}"
 
   if [[ -n ${COMPILER["ENV"]+x} ]] ; then
     # Visual Studio package - test for its environment variable
@@ -686,7 +686,7 @@ for i in $(reg query "$SDK_ROOT" 2>/dev/null | tr -d '\r' | sed -ne '/Windows\\v
         warning "SDK $i is not known to this script - assuming compatibility"
         DISPLAY="Windows SDK $i"
       else
-        eval COMPILER=${COMPILERS["SDK${i#v}"]}
+        eval "COMPILER=${COMPILERS["SDK${i#v}"]}"
         DISPLAY=${COMPILER['NAME']}
       fi
       RESULT=${COMPILERS['SDK']%)}
@@ -787,8 +787,8 @@ for i in $MSVS_PREFERENCE ; do
           fi
         done
         INSTANCES="$(sort -r <<< "${INSTANCES// /$'\n'}")"
-        eval TEST+=($INSTANCES)
-        eval PREFERENCE+=($INSTANCES)
+        eval "TEST+=($INSTANCES)"
+        eval "PREFERENCE+=($INSTANCES)"
       fi
     else
       if [[ -n ${CANDIDATES["VS$i"]+x} ]] ; then
@@ -798,7 +798,7 @@ for i in $MSVS_PREFERENCE ; do
       fi
       SDKS=
       for j in "${!COMPILERS[@]}" ; do
-        eval COMPILER=${COMPILERS[$j]}
+        eval "COMPILER=${COMPILERS["$j"]}"
         if [[ -n ${COMPILER["VC_VER"]+x} ]] ; then
           if [[ $i = ${COMPILER["VC_VER"]} && -n ${CANDIDATES[$j]+x} ]] ; then
             unset CANDIDATES[$j]
@@ -809,8 +809,8 @@ for i in $MSVS_PREFERENCE ; do
       SDKS=${SDKS% }
       SDKS="$(sort -r <<< "${SDKS// /$'\n'}")"
       SDKS=${SDKS//$'\n'/ }
-      eval TEST+=($SDKS)
-      eval PREFERENCE+=($SDKS)
+      eval "TEST+=($SDKS)"
+      eval "PREFERENCE+=($SDKS)"
     fi
   fi
 done
@@ -852,16 +852,16 @@ declare -A ARCHINFO
 
 for i in "${TEST[@]}" ; do
   CURRENT=${FOUND[$i]}
-  eval COMPILER=$CURRENT
+  eval "COMPILER=$CURRENT"
   # At the end of this process, the keys of FOUND will be augmented with the architecture found in
   # each case (so if "VS14.0" was in FOUND from the scan and both the x86 and x64 compilers are
   # valid, then at the end of this loop FOUND will contain "VS14.0-x86" and "VS14.0-x64").
   unset FOUND[$i]
 
   if [[ ${COMPILER["IS_EXPRESS"]}0 -gt 0 && -n ${COMPILER["EXPRESS_ARCH_SWITCHES"]+x} ]] ; then
-    eval ARCHINFO=${COMPILER["EXPRESS_ARCH_SWITCHES"]}
+    eval "ARCHINFO=${COMPILER['EXPRESS_ARCH_SWITCHES']}"
   elif [[ -n ${COMPILER["ARCH_SWITCHES"]+x} ]] ; then
-    eval ARCHINFO=${COMPILER["ARCH_SWITCHES"]}
+    eval "ARCHINFO=${COMPILER['ARCH_SWITCHES']}"
   else
     ARCHINFO=()
   fi
@@ -1083,7 +1083,7 @@ if [[ $MODE -eq 1 ]] ; then
 fi
 
 if [[ -n $SOLUTION ]] ; then
-  eval COMPILER=${FOUND[$SOLUTION-$LEFT_ARCH]}
+  eval "COMPILER=${FOUND["$SOLUTION-$LEFT_ARCH"]}"
   output MSVS_NAME "${COMPILER["DISPLAY"]}" $LEFT_ARCH
   output MSVS_PATH "${COMPILER["MSVS_PATH"]}" $LEFT_ARCH
   output MSVS_INC "${COMPILER["MSVS_INC"]}" $LEFT_ARCH
@@ -1092,7 +1092,7 @@ if [[ -n $SOLUTION ]] ; then
     output MSVS_ML "${COMPILER["ASSEMBLER"]%.exe}" always
   fi
   if [[ -z $TARGET_ARCH ]] ; then
-    eval COMPILER=${FOUND[$SOLUTION-$RIGHT_ARCH]}
+    eval "COMPILER=${FOUND["$SOLUTION-$RIGHT_ARCH"]}"
     output MSVS64_PATH "${COMPILER["MSVS_PATH"]}" $RIGHT_ARCH
     output MSVS64_INC "${COMPILER["MSVS_INC"]}" $RIGHT_ARCH
     output MSVS64_LIB "${COMPILER["MSVS_LIB"]}" $RIGHT_ARCH

--- a/msvs-detect
+++ b/msvs-detect
@@ -612,7 +612,7 @@ for i in "${!COMPILERS[@]}" ; do
     if [[ -n ${!ENV+x} ]] ; then
       debug "$ENV is a candidate"
       TEST_PATH=${!ENV%\"}
-      TEST_PATH=$(cygpath -u -f - <<< ${TEST_PATH#\"})
+      TEST_PATH=$(cygpath -u "${TEST_PATH#\"}")
       if [[ -e $TEST_PATH/vsvars32.bat ]] ; then
         debug "Directory pointed to by $ENV contains vsvars32.bat"
         EXPRESS=0
@@ -705,7 +705,7 @@ done
 VSWHERE=$(dirname $(realpath $0))/vswhere.exe
 if [[ ! -x $VSWHERE ]] ; then
   VSWHERE="$(printenv 'ProgramFiles(x86)')\\Microsoft Visual Studio\\Installer\\vswhere.exe"
-  VSWHERE=$(echo $VSWHERE| cygpath -f -)
+  VSWHERE=$(cygpath "$VSWHERE")
 fi
 if [[ -x $VSWHERE ]] ; then
   debug "$VSWHERE found"
@@ -722,7 +722,7 @@ if [[ -x $VSWHERE ]] ; then
       displayName)
         INSTANCE_NAME=${line#*: }
         debug "Looking at $INSTANCE in $INSTANCE_PATH ($INSTANCE_VER $INSTANCE_NAME)"
-        if [[ -e "$(echo $INSTANCE_PATH| cygpath -f -)/VC/Auxiliary/Build/vcvarsall.bat" ]] ; then
+        if [[ -e "$(cygpath "$INSTANCE_PATH")/VC/Auxiliary/Build/vcvarsall.bat" ]] ; then
           debug "vcvarsall.bat found"
           FOUND+=(["VS$INSTANCE_VER"]="([\"DISPLAY\"]=\"$INSTANCE_NAME\" [\"ARCH\"]=\"x86 x64\" [\"SETENV\"]=\"$INSTANCE_PATH\\VC\\Auxiliary\\Build\\vcvarsall.bat\" [\"SETENV_RELEASE\"]=\"\")")
         else
@@ -874,10 +874,10 @@ for i in "${TEST[@]}" ; do
     ENV=${!ENV%\"}
     ENV=${ENV#\"}
     if [[ ${COMPILER["ENV"]}0 -ge 800 ]] ; then
-      SCRIPT="$(cygpath -d -f - <<< $ENV)\\..\\..\\VC\\vcvarsall.bat"
+      SCRIPT="$(cygpath -d "$ENV")\\..\\..\\VC\\vcvarsall.bat"
       SCRIPT_SWITCHES=
     else
-      SCRIPT="$(cygpath -d -f - <<< $ENV)\\vsvars32.bat"
+      SCRIPT="$(cygpath -d "$ENV")\\vsvars32.bat"
       SCRIPT_SWITCHES=
     fi
   else
@@ -887,7 +887,7 @@ for i in "${TEST[@]}" ; do
   fi
   # For reasons of escaping, the script is executed using its basename so the directory needs
   # prepending to PATH.
-  DIR=$(dirname "$SCRIPT" | cygpath -u -f -)
+  DIR=$(cygpath -u "$(dirname "$SCRIPT")")
 
   if [[ ${COMPILER["IS_EXPRESS"]} -gt 0 && -n ${COMPILER["EXPRESS_ARCH"]+x} ]] ; then
     ARCHS=${COMPILER["EXPRESS_ARCH"]}
@@ -956,7 +956,7 @@ for i in "${TEST[@]}" ; do
     if [[ ${i/.*/} = "VS7" ]] ; then
       find_in "${MSVS_PATH//:/*}" mt.exe
       if [[ $RET -eq 1 ]] ; then
-        MSVS_PATH="$MSVS_PATH$(cygpath -u -f - <<< $ENV\\Bin\\winnt):"
+        MSVS_PATH="$MSVS_PATH$(cygpath -u "$ENV\\Bin\\winnt"):"
         RET=0
       fi
     fi

--- a/msvs-promote-path
+++ b/msvs-promote-path
@@ -58,4 +58,13 @@ done
 unset IFS
 
 echo "$clpath moved to the front of \$PATH">&2
+
+# The final step is to output
+#   export PATH='...'
+# $NEWPATH may contain single quotes, therefore this is done by disabling globbing (set -f) and
+# disabling word splitting (IFS='') and then replacing every single quote with the standard '"\'"'
+# pattern.
+set -f
+IFS=''
+# shellcheck disable=SC2027,SC2086 # set -f and IFS='' in force
 echo "export PATH='"${NEWPATH//\'/\'\"\'\"\'}"'"

--- a/msvs-promote-path
+++ b/msvs-promote-path
@@ -42,7 +42,7 @@ if ! linkpath="$(command -v link)" ; then
   exit 1
 fi
 
-if [ "${linkpath%/*}" = "$clpath" ]; then
+if [[ ${linkpath%/*} = "$clpath" ]]; then
   echo "link already refers to the Microsoft Linker">&2
   exit 0
 fi
@@ -51,7 +51,7 @@ NEWPATH="$clpath"
 IFS=:
 for i in $PATH
 do
-  if [[ $i != $clpath ]]; then
+  if [[ $i != "$clpath" ]]; then
     NEWPATH="$NEWPATH:$i"
   fi
 done


### PR DESCRIPTION
Addresses the parts of #7 which I was uncertain about reviewing at the time in terms of purpose, rather than shellcheck test number. Today I learned that given:

```bash
i=0
FOO=(a b)
```
both

```bash
unset 'FOO[$i]'
```

and

```bash
unset "FOO[$i]"
```

are in fact equivalent, but given that neither GitHub's nor my editor's syntax highlighting understands that the variable in the first one really is a variable, I went with the second syntax, just for the highlight that `$i` is not literal.

With this PR, both scripts pass shellcheck 0.9.0.